### PR TITLE
Refactor vehicle ID inference from train vehicle number

### DIFF
--- a/src/components/TrainWagonSm5.tsx
+++ b/src/components/TrainWagonSm5.tsx
@@ -14,7 +14,7 @@ type TrainWagonSm5Props = {
  */
 export function TrainWagonSm5({ vehicleId }: TrainWagonSm5Props) {
   const vehicleDoorStatus = useReactiveVarWithSelector(vehiclesVar, (v) =>
-    vehicleId ? v[vehicleId].drst : null
+    vehicleId && vehicleId in v ? v[vehicleId].drst : null
   );
 
   const doorsOpen = vehicleDoorStatus === 1;

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -7,6 +7,7 @@ import {
 import { makeVar } from '@apollo/client';
 
 import { VehicleDetails } from '../types/vehicles';
+import getTrainVehicleIdFromTrainEuropeanVehicleNumber from '../utils/getTrainVehicleIdFromTrainEuropeanVehicleNumber';
 
 /**
  * Holds the real-time state information of the vehicles.
@@ -45,84 +46,6 @@ const digitrafficLink = new HttpLink({
 const vrLink = new HttpLink({
   uri: '/vr-api',
 });
-
-/**
- * Gets the train vehicle ID from the given European Vehicle Number (EVN) and the type of the train unit.
- *
- * @remarks
- * In Finland, all train units have European Vehicle Number (EVN) with format
- * 9410xxxxxxx-c where the last digits before the checksum (c) correspond to
- * the unit number.
- *
- * @see https://en.wikipedia.org/wiki/UIC_identification_marking_for_tractive_stock
- *
- * @example
- * // Returns 6088 as the vehicle ID
- * getTrainVehicleIdFromTrainEuropeanVehicleNumber('94106000088-7', 'Sm2')
- *
- * @example
- * // Returns 6324 as the vehicle ID
- * getTrainVehicleIdFromTrainEuropeanVehicleNumber('94106004024-8', 'Sm4')
- *
- * @example
- * // Returns 1038 as the vehicle ID
- * getTrainVehicleIdFromTrainEuropeanVehicleNumber('94102081038-3', 'Sm5')
- *
- * @param vehicleNumber The European Vehicle Number (EVN) of the train unit.
- * @param wagonType The wagon type. E.g. Sm5.
- * @returns The four digit train vehicle ID.
- */
-const getTrainVehicleIdFromTrainEuropeanVehicleNumber = (
-  vehicleNumber: string,
-  wagonType: string
-): number | null => {
-  if (wagonType === 'Sm1' || wagonType === 'Sm2') {
-    // The Sm1 units are numbered from 6001 to 6050 for the motored car.
-    // See https://en.wikipedia.org/wiki/VR_Class_Sm1
-    // Examples:
-    // * 94106000001-0 = 6001
-    // * 94106000025-9 = 6025
-    // * 94106000050-7 = 6050
-    //
-    // The Sm2 units are numbered from 6051 to 6100 for the motored car.
-    // See https://en.wikipedia.org/wiki/VR_Class_Sm2
-    // Examples:
-    // * 94106000088-7 = 6088
-    // * 94106000066-3 = 6066
-    // * 94106000091-1 = 6091
-    const matches = vehicleNumber.match(/9410\d{4}(\d{3})-\d/);
-    if (matches !== null && matches.length === 2) {
-      return Number.parseInt('6' + matches[1], 10);
-    }
-  }
-  if (wagonType === 'Sm4') {
-    // The Sm4 units are in the form of 63xx for the motored car.
-    // See https://en.wikipedia.org/wiki/VR_Class_Sm4
-    // Examples:
-    // 94106004024-8 = 6324
-    // 94106004008-1 = 6308
-    // 94106004025-5 = 6325
-    const matches = vehicleNumber.match(/9410\d{5}(\d{2})-\d/);
-    if (matches !== null && matches.length === 2) {
-      return Number.parseInt('63' + matches[1], 10);
-    }
-  }
-  if (wagonType === 'Sm5') {
-    // The Sm5 units have vehicle numbers from 94102081 001 to 94102081 081.
-    // The last 4 digits before the EVN checksum form the unit number.
-    // See https://en.wikipedia.org/wiki/JKOY_Class_Sm5
-    // Examples:
-    // * 94102081038-3 = 1038
-    // * 94102081078-9 = 1078
-    // * 94102081069-8 = 1069
-    const matches = vehicleNumber.match(/9410\d{3}(\d{4})-\d/);
-    if (matches !== null && matches.length === 2) {
-      return Number.parseInt(matches[1], 10);
-    }
-  }
-
-  return null;
-};
 
 export const client = new ApolloClient({
   link: ApolloLink.split(

--- a/src/utils/__tests__/getTrainVehicleIdFromTrainEuropeanVehicleNumber.test.ts
+++ b/src/utils/__tests__/getTrainVehicleIdFromTrainEuropeanVehicleNumber.test.ts
@@ -1,0 +1,30 @@
+import getTrainVehicleIdFromTrainEuropeanVehicleNumber from '../getTrainVehicleIdFromTrainEuropeanVehicleNumber';
+
+describe('getTrainVehicleIdFromTrainEuropeanVehicleNumber', () => {
+  it('should return null when vehicle ID cannot be determined', () => {
+    expect(
+      getTrainVehicleIdFromTrainEuropeanVehicleNumber(
+        '94106000001-0',
+        'NoSuchWagonType'
+      )
+    ).toBeNull();
+  });
+
+  it('should return correct vehicle ID for the given vehicle number and wagon type', () => {
+    expect(
+      getTrainVehicleIdFromTrainEuropeanVehicleNumber('94106000001-0', 'Sm1')
+    ).toBe(6001);
+
+    expect(
+      getTrainVehicleIdFromTrainEuropeanVehicleNumber('94106000088-7', 'Sm2')
+    ).toBe(6088);
+
+    expect(
+      getTrainVehicleIdFromTrainEuropeanVehicleNumber('94106004024-8', 'Sm4')
+    ).toBe(6324);
+
+    expect(
+      getTrainVehicleIdFromTrainEuropeanVehicleNumber('94102081038-3', 'Sm5')
+    ).toBe(1038);
+  });
+});

--- a/src/utils/getTrainVehicleIdFromTrainEuropeanVehicleNumber.ts
+++ b/src/utils/getTrainVehicleIdFromTrainEuropeanVehicleNumber.ts
@@ -1,0 +1,77 @@
+/**
+ * Gets the train vehicle ID from the given European Vehicle Number (EVN) and the type of the train unit.
+ *
+ * @remarks
+ * In Finland, all train units have European Vehicle Number (EVN) with format
+ * 9410xxxxxxx-c where the last digits before the checksum (c) correspond to
+ * the unit number.
+ *
+ * @see https://en.wikipedia.org/wiki/UIC_identification_marking_for_tractive_stock
+ *
+ * @example
+ * // Returns 6088 as the vehicle ID
+ * getTrainVehicleIdFromTrainEuropeanVehicleNumber('94106000088-7', 'Sm2')
+ *
+ * @example
+ * // Returns 6324 as the vehicle ID
+ * getTrainVehicleIdFromTrainEuropeanVehicleNumber('94106004024-8', 'Sm4')
+ *
+ * @example
+ * // Returns 1038 as the vehicle ID
+ * getTrainVehicleIdFromTrainEuropeanVehicleNumber('94102081038-3', 'Sm5')
+ *
+ * @param vehicleNumber The European Vehicle Number (EVN) of the train unit.
+ * @param wagonType The wagon type. E.g. Sm5.
+ * @returns The four digit train vehicle ID.
+ */
+export default function getTrainVehicleIdFromTrainEuropeanVehicleNumber(
+  vehicleNumber: string,
+  wagonType: string
+): number | null {
+  if (wagonType === 'Sm1' || wagonType === 'Sm2') {
+    // The Sm1 units are numbered from 6001 to 6050 for the motored car.
+    // See https://en.wikipedia.org/wiki/VR_Class_Sm1
+    // Examples:
+    // * 94106000001-0 = 6001
+    // * 94106000025-9 = 6025
+    // * 94106000050-7 = 6050
+    //
+    // The Sm2 units are numbered from 6051 to 6100 for the motored car.
+    // See https://en.wikipedia.org/wiki/VR_Class_Sm2
+    // Examples:
+    // * 94106000088-7 = 6088
+    // * 94106000066-3 = 6066
+    // * 94106000091-1 = 6091
+    const matches = vehicleNumber.match(/9410\d{4}(\d{3})-\d/);
+    if (matches !== null && matches.length === 2) {
+      return Number.parseInt('6' + matches[1], 10);
+    }
+  }
+  if (wagonType === 'Sm4') {
+    // The Sm4 units are in the form of 63xx for the motored car.
+    // See https://en.wikipedia.org/wiki/VR_Class_Sm4
+    // Examples:
+    // 94106004024-8 = 6324
+    // 94106004008-1 = 6308
+    // 94106004025-5 = 6325
+    const matches = vehicleNumber.match(/9410\d{5}(\d{2})-\d/);
+    if (matches !== null && matches.length === 2) {
+      return Number.parseInt('63' + matches[1], 10);
+    }
+  }
+  if (wagonType === 'Sm5') {
+    // The Sm5 units have vehicle numbers from 94102081 001 to 94102081 081.
+    // The last 4 digits before the EVN checksum form the unit number.
+    // See https://en.wikipedia.org/wiki/JKOY_Class_Sm5
+    // Examples:
+    // * 94102081038-3 = 1038
+    // * 94102081078-9 = 1078
+    // * 94102081069-8 = 1069
+    const matches = vehicleNumber.match(/9410\d{3}(\d{4})-\d/);
+    if (matches !== null && matches.length === 2) {
+      return Number.parseInt(matches[1], 10);
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
- No more using vehiclesVar to fetch vehicle ID but infering the vehicle ID directly using train vehicleNumber and wagonType information
- Move getTrainVehicleIdFromTrainEuropeanVehicleNumber to own file
- Add tests for getTrainVehicleIdFromTrainEuropeanVehicleNumber