### PR TITLE
Use special handling for LEN (airport) station

### DIFF
--- a/src/components/StationTimeTableRow.tsx
+++ b/src/components/StationTimeTableRow.tsx
@@ -8,7 +8,7 @@ import {
   TableCell,
   TableRow,
 } from '@mui/material';
-import { ChevronRight } from 'mdi-material-ui';
+import { Airplane, ChevronRight } from 'mdi-material-ui';
 import RouterLink from 'next/link';
 
 import {
@@ -47,7 +47,7 @@ function StationTimeTableRow({
     : train.trainType.name + train.trainNumber;
   const deptOrDestStation =
     timeTableType === TimeTableRowType.Departure
-      ? getTrainDestinationStation(train)
+      ? getTrainDestinationStation(train, stationCode)
       : getTrainDepartureStation(train);
   const deptOrDestStationName = deptOrDestStation
     ? getTrainStationName(deptOrDestStation)
@@ -111,6 +111,9 @@ function StationTimeTableRow({
           onClick={handleStationClick}
         >
           {deptOrDestStationName}
+          {deptOrDestStation?.shortCode === 'LEN' && (
+            <Airplane sx={{ position: 'absolute', fontSize: '1.3rem' }} />
+          )}
         </Link>
       </TableCell>
       <TableCell align="center">

--- a/src/utils/train.ts
+++ b/src/utils/train.ts
@@ -51,7 +51,7 @@ export function getTrainDestinationStation(
     const stationRow = getTimeTableRowForStation(
       stationCode,
       train,
-      TimeTableRowType.Arrival
+      TimeTableRowType.Departure
     );
     const airportArrivalRow = getTimeTableRowForStation(
       'LEN',

--- a/src/utils/train.ts
+++ b/src/utils/train.ts
@@ -1,7 +1,12 @@
 import { parseISO } from 'date-fns';
 import { orderBy } from 'lodash';
 
-import { TrainByStationFragment } from '../graphql/generated/digitraffic';
+import {
+  TimeTableRowType,
+  TrainByStationFragment,
+} from '../graphql/generated/digitraffic';
+
+import getTimeTableRowForStation from './getTimeTableRowForStation';
 
 export function getTimeTableRowRealTime(row: {
   scheduledTime: string;
@@ -30,7 +35,37 @@ export function getTrainDepartureStation(train: TrainByStationFragment) {
   return getDepartureTimeTableRow(train)?.station;
 }
 
-export function getTrainDestinationStation(train: TrainByStationFragment) {
+export function getTrainDestinationStation(
+  train: TrainByStationFragment,
+  stationCode?: string
+) {
+  // Special handling for ring route (kehärata) trains:
+  // Return LEN (airport) as the destination station if
+  // the given station code is earlier on the train
+  // time table rows than the airport.
+  if (
+    stationCode &&
+    train.commuterLineid &&
+    ['I', 'P'].includes(train.commuterLineid)
+  ) {
+    const stationRow = getTimeTableRowForStation(
+      stationCode,
+      train,
+      TimeTableRowType.Arrival
+    );
+    const airportArrivalRow = getTimeTableRowForStation(
+      'LEN',
+      train,
+      TimeTableRowType.Arrival
+    );
+    if (
+      airportArrivalRow &&
+      stationRow &&
+      stationRow.scheduledTime < airportArrivalRow.scheduledTime
+    ) {
+      return airportArrivalRow.station;
+    }
+  }
   return getDestinationTimeTableRow(train)?.station;
 }
 
@@ -39,15 +74,18 @@ export function getTrainDepartureStationName(train: TrainByStationFragment) {
   return departureStation ? getTrainStationName(departureStation) : undefined;
 }
 
-export function getTrainDestinationStationName(train: TrainByStationFragment) {
-  const destinationStation = getTrainDestinationStation(train);
+export function getTrainDestinationStationName(
+  train: TrainByStationFragment,
+  stationCode?: string
+) {
+  const destinationStation = getTrainDestinationStation(train, stationCode);
   return destinationStation
     ? getTrainStationName(destinationStation)
     : undefined;
 }
 
 export function getTrainStationName(station: { name: string }) {
-  return station.name.replace('asema', '').trimEnd();
+  return station.name.replace(' asema', '').trimEnd();
 }
 
 export function getWagonNumberFromVehicleId(


### PR DESCRIPTION
- Use special handling for ring route (kehärata) trains to show LEN as destination station if the given station code is earlier on the train time table rows than LEN
- Display airplane icon next to LEN station name on StationTimeTableRow
- Fix issue where Lentoasema name was shown as Lento