### PR TITLE
Update hsl-map-style in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30939,7 +30939,7 @@
     "hsl-map-style": {
       "version": "git+ssh://git@github.com/HSLdevcom/hsl-map-style.git#207a8de2664c9a50b5a5f886d30f5b1628f995c7",
       "integrity": "sha512-RGuYzld0pXa3uKY7uQEnHQntNW48fG2f+grbMzUINn1i1KeI/WyP8RGhIwzXH83+iUUVf2qTeUxvHtSK3jx1WQ==",
-      "from": "hsl-map-style@github:HSLdevcom/hsl-map-style#207a8de2664c9a50b5a5f886d30f5b1628f995c7",
+      "from": "hsl-map-style@github:HSLdevcom/hsl-map-style#master",
       "requires": {
         "lodash": "^4.17.4"
       }


### PR DESCRIPTION
Updates the "from" field of the hsl-map-style in package-lock.json that Dependabot changed in an earlier commit.