### PR TITLE
Define cache ID for Operator type to ensure safe cache merges

### DIFF
--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -173,6 +173,9 @@ export const client = new ApolloClient({
           },
         },
       },
+      Operator: {
+        keyFields: ['uicCode'],
+      },
       Query: {
         fields: {
           trainsByStationAndQuantity: {


### PR DESCRIPTION
Fixes the Apollo client warning: "Cache data may be lost when replacing the operator field of a Train object."