### PR TITLE
Fix logic for generating train route GTFS ID

### DIFF
--- a/src/utils/__tests__/train.test.ts
+++ b/src/utils/__tests__/train.test.ts
@@ -426,7 +426,7 @@ describe('getTrainRouteGtfsId', () => {
       commuterLineid: 'U',
       trainNumber: 1234,
       trainType: {
-        name: '',
+        name: 'HL',
         trainCategory: {
           name: 'Commuter',
         },
@@ -451,7 +451,7 @@ describe('getTrainRouteGtfsId', () => {
       ],
     };
     const displayName = getTrainRouteGtfsId(train);
-    expect(displayName).toBe('digitraffic:HKI_KKN_U_109_10');
+    expect(displayName).toBe('digitraffic:HKI_KKN_U_HL_10');
   });
 
   it('should return correct GTFS ID for a long distance train', () => {
@@ -459,7 +459,7 @@ describe('getTrainRouteGtfsId', () => {
       ...trainBase,
       trainNumber: 1234,
       trainType: {
-        name: '',
+        name: 'IC',
         trainCategory: {
           name: 'Long-distance',
         },
@@ -487,6 +487,6 @@ describe('getTrainRouteGtfsId', () => {
       ],
     };
     const displayName = getTrainRouteGtfsId(train);
-    expect(displayName).toBe('digitraffic:HKI_TPE_1234_102_987');
+    expect(displayName).toBe('digitraffic:HKI_TPE_1234_IC_987');
   });
 });

--- a/src/utils/train.ts
+++ b/src/utils/train.ts
@@ -114,31 +114,18 @@ export function getTrainDisplayName(train: TrainByStationFragment) {
 }
 
 /**
- * A map from the the Digitraffic train category name to the GTFS extended route type (integer).
- * - 109 = Suburban Railway - used in Finland for commuter rails
- * - 102 = Long Distance Trains - used in Finland for IC, S, and regional (HDM) trains
- *
- * @see https://developers.google.com/transit/gtfs/reference/extended-route-type
- */
-const trainCategoryNameToGtfsRouteTypeMap: Record<string, number> = {
-  'Long-distance': 102,
-  Commuter: 109,
-};
-
-/**
  * Gets the train route GTFS ID used in Digitransit routing API.
  *
  * @example
- * // returns "digitraffic:TPE_HKI_R_109_10"
+ * // returns "digitraffic:TPE_HKI_R_HL_10"
  * getTrainRouteGtfsId(<R train from Tampere to Helsinki operated by VR>);
  */
 export function getTrainRouteGtfsId(train: TrainByStationFragment) {
   const deptStationCode = getTrainDepartureStation(train)?.shortCode;
   const destStationCode = getTrainDestinationStation(train)?.shortCode;
-  const routeType =
-    trainCategoryNameToGtfsRouteTypeMap[train.trainType.trainCategory.name];
+  const trainType = train.trainType.name;
   const agency = train.operator.uicCode;
   return `digitraffic:${deptStationCode}_${destStationCode}_${
     train.commuterLineid ? train.commuterLineid : train.trainNumber
-  }_${routeType}_${agency}`;
+  }_${trainType}_${agency}`;
 }


### PR DESCRIPTION
Digitraffic has changed how the train route IDs are presented in GTFS.