### PR TITLE
Use Digitransit Map v3 and use GTFS IDs in StopsLayer for matching

### DIFF
--- a/src/utils/__tests__/train.test.ts
+++ b/src/utils/__tests__/train.test.ts
@@ -17,6 +17,7 @@ import {
   getWagonNumberFromVehicleId,
   getTrainDisplayName,
   getTrainRouteGtfsId,
+  getTrainStationGtfsId,
 } from '../train';
 
 const trainBase: TrainDetailsFragment = {
@@ -489,4 +490,17 @@ describe('getTrainRouteGtfsId', () => {
     const displayName = getTrainRouteGtfsId(train);
     expect(displayName).toBe('digitraffic:HKI_TPE_1234_IC_987');
   });
+});
+
+describe('getTrainStationGtfsId', () => {
+  it.each([
+    ['HKI', 'digitraffic:HKI'],
+    ['PSL', 'digitraffic:PSL'],
+  ])(
+    'should return correct GTFS ID for the station %s',
+    (shortCode, expectedGtfsId) => {
+      const gtfsId = getTrainStationGtfsId({ shortCode });
+      expect(gtfsId).toBe(expectedGtfsId);
+    }
+  );
 });

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -148,6 +148,16 @@ const generateMapStyle = (options?: Options) => {
     ],
   });
   (mapStyle.sources['vector'] as VectorSource).attribution = baseAttribution;
+
+  // Temporary workaround to use v3 vector map instead of v2
+  // To be removed after hsl-map-style package supports v3
+  const sourcesToUpdate = ['vector'];
+  Object.entries(mapStyle.sources).forEach(([sourceKey, source]) => {
+    if (sourcesToUpdate.includes(sourceKey) && 'url' in source) {
+      source.url = source.url?.replace('v2', 'v3');
+    }
+  });
+
   return mapStyle;
 };
 
@@ -190,8 +200,8 @@ const getRasterMapStyle = (
       type: 'raster',
       tiles: [
         isDarkMode
-          ? 'https://cdn.digitransit.fi/map/v2/hsl-map-greyscale/{z}/{x}/{y}.png'
-          : 'https://cdn.digitransit.fi/map/v2/hsl-map/{z}/{x}/{y}.png',
+          ? 'https://cdn.digitransit.fi/map/v3/hsl-map-greyscale/{z}/{x}/{y}.png'
+          : 'https://cdn.digitransit.fi/map/v3/hsl-map/{z}/{x}/{y}.png',
       ],
       tileSize: 512,
       attribution: baseAttribution,

--- a/src/utils/train.ts
+++ b/src/utils/train.ts
@@ -2,6 +2,7 @@ import { parseISO } from 'date-fns';
 import { orderBy } from 'lodash';
 
 import {
+  Station,
   TimeTableRowType,
   TrainByStationFragment,
 } from '../graphql/generated/digitraffic/graphql';
@@ -89,8 +90,12 @@ export function getTrainDestinationStationName(
     : undefined;
 }
 
-export function getTrainStationName(station: { name: string }) {
+export function getTrainStationName(station: Pick<Station, 'name'>) {
   return station.name.replace(' asema', '').trimEnd();
+}
+
+export function getTrainStationGtfsId(station: Pick<Station, 'shortCode'>) {
+  return `digitraffic:${station.shortCode}`;
 }
 
 export function getWagonNumberFromVehicleId(


### PR DESCRIPTION
- Switch to Digitransit Map v3 API
- Update StopsLayer to use new Digitransit Map v3 API Points of interest source
- Make StopsLayer use GTFS IDs for matching stations instead of station names