### PR TITLE
Fix issue in StopsLayer displaying duplicate data after V3 map update

### DIFF
--- a/src/components/map/StopsLayer.tsx
+++ b/src/components/map/StopsLayer.tsx
@@ -180,7 +180,11 @@ const StopsLayer = ({ train }: StopsLayerProps) => {
           type: 'circle',
           source: 'stops',
           'source-layer': 'stations',
-          filter: ['==', 'type', 'RAIL'],
+          filter: [
+            'all',
+            ['==', ['get', 'type'], 'RAIL'],
+            ['==', ['index-of', 'digitraffic', ['get', 'gtfsId']], 0],
+          ],
           paint: {
             'circle-color': routeStationGtfsIds
               ? getPropertyValueByStationGtfsId(
@@ -203,7 +207,11 @@ const StopsLayer = ({ train }: StopsLayerProps) => {
           type: 'symbol',
           source: 'stops',
           'source-layer': 'stations',
-          filter: ['==', 'type', 'RAIL'],
+          filter: [
+            'all',
+            ['==', ['get', 'type'], 'RAIL'],
+            ['==', ['index-of', 'digitraffic', ['get', 'gtfsId']], 0],
+          ],
           layout: {
             'text-optional': true,
             'text-allow-overlap': currentZoom != null && currentZoom > 10,
@@ -278,7 +286,12 @@ const StopsLayer = ({ train }: StopsLayerProps) => {
           type: 'symbol',
           source: 'stops',
           'source-layer': 'stops',
-          filter: ['all', ['==', 'type', 'RAIL'], ['has', 'platform']],
+          filter: [
+            'all',
+            ['==', ['get', 'type'], 'RAIL'],
+            ['has', 'platform'],
+            ['==', ['index-of', 'digitraffic', ['get', 'gtfsId']], 0],
+          ],
           minzoom: 14,
           layout: {
             'icon-image': 'stop-marker',


### PR DESCRIPTION
Digitransit Map Points of interest API V3 contains duplicate data for different GTFS ID codespaces (HSL + MATKA + digitraffic). Only display those features that have GTFS ID property starting with "digitraffic" prefix.