### PR TITLE
Fix bug where service worker is precaching non-existent Next.js file

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -36,7 +36,7 @@ const nextConfig: NextConfig = {
             ({ asset }) =>
               asset.name.startsWith('server/') ||
               asset.name.match(
-                /^((app-|^)build-manifest\.json|react-loadable-manifest\.json)$/
+                /^((app-|^)build-manifest\.json|react-loadable-manifest\.json|dynamic-css-manifest\.json)$/
               ),
           ],
           modifyURLPrefix: {


### PR DESCRIPTION
Prevents service worker from trying to precache non-existent `_next/dynamic-css-manifest.json` file.

Currently service worker registration is failing with the following error:
```
Uncaught (in promise) bad-precaching-response: bad-precaching-response :: [{"url":"https://junaan.fi/_next/dynamic-css-manifest.json","status":404}]
    at V._handleInstall (https://junaan.fi/service-worker.js:1:26388)
    at async V._handle (https://junaan.fi/service-worker.js:1:25805)
    at async V._getResponse (https://junaan.fi/service-worker.js:1:24883)
```
This change should fix it.